### PR TITLE
Fix ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ gem install somemoji
 ## Command line tool
 
 `somemoji` executable is bundled to extract images from each emoji provider.
+**※provider apple on macOS Sierra or later**.
 
 ```
 $ somemoji --help


### PR DESCRIPTION
The extract command is from mac OS Sieera or later onwards if provider is apple.
Because gemoji 's gem that it depends on is like that.
Because I am mac OS ElCapitan, the command could not be executed.

sorry.
I corrected it because it was not accurate:bow:

[gemoji](https://github.com/github/gemoji)

>Extract images
>To obtain image files as fallbacks for browsers and OS's that don't support emoji, run the gemoji extract command on macOS Sierra or later: